### PR TITLE
Some love for Windows users: changes build scripts to allow starting …

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "prettier:base": "prettier --parser typescript --single-quote",
     "prettier:check": "npm run prettier:base -- --list-different \"imports/**/*.{ts,tsx}\"",
     "prettier:write": "npm run prettier:base -- --write \"imports/**/*.{ts,tsx}\"",
-    "build:graphql": "echo \"GraphQL file has changed: Deleting old cached files!\" && rm -rf ./node_modules/.cache/babel-loader",
-    "watch": "watch 'npm run build:graphql' ./imports/api"
+    "build:graphql": "echo \"GraphQL file has changed: Deleting old cached files!\" && npx rimraf ./node_modules/.cache/babel-loader",
+    "watch": "watch \"npm run build:graphql\" ./imports/api"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",


### PR DESCRIPTION
…the watch and build processes without errors.

On Windows machines, you don't have "rm" unless you are using an external environment, like Cmder or Windows Subsystem. This commit allows standard execution of the start task.

<!-- gk-ai-analysis-start:fd31e2aedf90fca0150c51761cb8a3b392e9f3a5 -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiUmVwbGFjZXMgdGhlIGBybSAtcmZgIGNvbW1hbmQgaW4gdGhlIGBidWlsZDpncmFwaHFsYCBzY3JpcHQgd2l0aCBgbnB4IHJpbXJhZmAgdG8gaW1wcm92ZSBjcm9zcy1wbGF0Zm9ybSBjb21wYXRpYmlsaXR5LCBwYXJ0aWN1bGFybHkgZm9yIFdpbmRvd3MuIiwia2V5SW5zaWdodHMiOlt7InRpdGxlIjoiQ3Jvc3MtcGxhdGZvcm0gZmlsZSBkZWxldGlvbiIsImRlc2NyaXB0aW9uIjoiUmVwbGFjZWQgVW5peC1zcGVjaWZpYyBgcm0gLXJmYCB3aXRoIGBucHggcmltcmFmYCBpbiB0aGUgYGJ1aWxkOmdyYXBocWxgIHNjcmlwdCB0byBlbnN1cmUgaXQgd29ya3Mgb24gV2luZG93cyBlbnZpcm9ubWVudHMgd2l0aG91dCByZXF1aXJpbmcgV1NMIG9yIGV4dGVybmFsIHRvb2xzLiIsInNldmVyaXR5IjoibG93IiwiZmlsZVBhdGgiOiJwYWNrYWdlLmpzb24iLCJsaW5lU3RhcnQiOjE1fSx7InRpdGxlIjoiUXVvdGUgc3R5bGUgdXBkYXRlIGluIHdhdGNoIHNjcmlwdCIsImRlc2NyaXB0aW9uIjoiQ2hhbmdlZCBzaW5nbGUgcXVvdGVzIHRvIGRvdWJsZSBxdW90ZXMgYXJvdW5kIHRoZSBucG0gY29tbWFuZCBpbiB0aGUgYHdhdGNoYCBzY3JpcHQuIiwic2V2ZXJpdHkiOiJsb3ciLCJmaWxlUGF0aCI6InBhY2thZ2UuanNvbiIsImxpbmVTdGFydCI6MTZ9XSwiaXNzdWVzIjpbXSwic3VnZ2VzdGlvbnMiOltdLCJzZWN1cml0eSI6W119 -->
<!-- gk-ai-analysis-end:fd31e2aedf90fca0150c51761cb8a3b392e9f3a5 -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/alexjackhughes/titan/pull/2?source=pr_review_chip">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->